### PR TITLE
Qcv1 2 upload images

### DIFF
--- a/backend/composer.json
+++ b/backend/composer.json
@@ -30,7 +30,8 @@
         "symfony/serializer": "6.4.*",
         "symfony/twig-bundle": "6.4.*",
         "symfony/validator": "6.4.*",
-        "symfony/yaml": "6.4.*"
+        "symfony/yaml": "6.4.*",
+        "vich/uploader-bundle": "^2.7"
     },
     "config": {
         "allow-plugins": {

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "804e0547f59a0bfcd47cab24cdd6bd6b",
+    "content-hash": "858f65366c8d6a3160796f2e8305580a",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -2423,6 +2423,70 @@
                 "source": "https://github.com/doctrine/sql-formatter/tree/1.5.2"
             },
             "time": "2025-01-24T11:45:48+00:00"
+        },
+        {
+            "name": "jms/metadata",
+            "version": "2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/metadata.git",
+                "reference": "7ca240dcac0c655eb15933ee55736ccd2ea0d7a6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/metadata/zipball/7ca240dcac0c655eb15933ee55736ccd2ea0d7a6",
+                "reference": "7ca240dcac0c655eb15933ee55736ccd2ea0d7a6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "doctrine/cache": "^1.0",
+                "doctrine/coding-standard": "^8.0",
+                "mikey179/vfsstream": "^1.6.7",
+                "phpunit/phpunit": "^8.5|^9.0",
+                "psr/container": "^1.0|^2.0",
+                "symfony/cache": "^3.1|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.1|^4.0|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Metadata\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "Class/method/property metadata management in PHP",
+            "keywords": [
+                "annotations",
+                "metadata",
+                "xml",
+                "yaml"
+            ],
+            "support": {
+                "issues": "https://github.com/schmittjoh/metadata/issues",
+                "source": "https://github.com/schmittjoh/metadata/tree/2.8.0"
+            },
+            "time": "2023-02-15T13:44:18+00:00"
         },
         {
             "name": "maennchen/zipstream-php",
@@ -5228,6 +5292,95 @@
             "time": "2025-07-31T09:23:30+00:00"
         },
         {
+            "name": "symfony/mime",
+            "version": "v6.4.24",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mime.git",
+                "reference": "664d5e844a2de5e11c8255d0aef6bc15a9660ac7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/664d5e844a2de5e11c8255d0aef6bc15a9660ac7",
+                "reference": "664d5e844a2de5e11c8255d0aef6bc15a9660ac7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "conflict": {
+                "egulias/email-validator": "~3.0.0",
+                "phpdocumentor/reflection-docblock": "<3.2.2",
+                "phpdocumentor/type-resolver": "<1.4.0",
+                "symfony/mailer": "<5.4",
+                "symfony/serializer": "<6.4.3|>7.0,<7.0.3"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10|^3.1|^4",
+                "league/html-to-markdown": "^5.0",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.4|^7.0",
+                "symfony/property-access": "^5.4|^6.0|^7.0",
+                "symfony/property-info": "^5.4|^6.0|^7.0",
+                "symfony/serializer": "^6.4.3|^7.0.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mime\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows manipulating MIME messages",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mime",
+                "mime-type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/mime/tree/v6.4.24"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-15T12:02:45+00:00"
+        },
+        {
             "name": "symfony/password-hasher",
             "version": "v6.4.24",
             "source": {
@@ -5380,6 +5533,89 @@
                 }
             ],
             "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.32.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "symfony/polyfill-intl-normalizer": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Trevor Rowbotham",
+                    "email": "trevor.rowbotham@pm.me"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.32.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-10T14:38:51+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
@@ -7777,6 +8013,114 @@
                 }
             ],
             "time": "2025-05-03T07:21:55+00:00"
+        },
+        {
+            "name": "vich/uploader-bundle",
+            "version": "v2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dustin10/VichUploaderBundle.git",
+                "reference": "8a8cce134fc686caadf6828956f8ddd2b383fe74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dustin10/VichUploaderBundle/zipball/8a8cce134fc686caadf6828956f8ddd2b383fe74",
+                "reference": "8a8cce134fc686caadf6828956f8ddd2b383fe74",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/persistence": "^3.0 || ^4.0",
+                "ext-simplexml": "*",
+                "jms/metadata": "^2.4",
+                "php": "^8.1",
+                "symfony/config": "^5.4 || ^6.0 || ^7.0",
+                "symfony/console": "^5.4 || ^6.0 || ^7.0",
+                "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
+                "symfony/event-dispatcher-contracts": "^3.1",
+                "symfony/http-foundation": "^5.4 || ^6.0 || ^7.0",
+                "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
+                "symfony/mime": "^5.4 || ^6.0 || ^7.0",
+                "symfony/property-access": "^5.4 || ^6.0 || ^7.0",
+                "symfony/string": "^5.4 || ^6.0 || ^7.0"
+            },
+            "conflict": {
+                "doctrine/annotations": "<1.12",
+                "league/flysystem": "<2.0"
+            },
+            "require-dev": {
+                "dg/bypass-finals": "^1.9",
+                "doctrine/common": "^3.0",
+                "doctrine/doctrine-bundle": "^2.7",
+                "doctrine/mongodb-odm": "^2.4",
+                "doctrine/orm": "^2.13 || ^3.0",
+                "ext-sqlite3": "*",
+                "knplabs/knp-gaufrette-bundle": "dev-master",
+                "league/flysystem-bundle": "^2.4 || ^3.0",
+                "league/flysystem-memory": "^2.0 || ^3.0",
+                "matthiasnoback/symfony-dependency-injection-test": "^5.1",
+                "mikey179/vfsstream": "^1.6.11",
+                "phpunit/phpunit": "^10.5 || ^11.5 || ^12.0",
+                "symfony/asset": "^5.4 || ^6.0 || ^7.0",
+                "symfony/browser-kit": "^5.4 || ^6.0 || ^7.0",
+                "symfony/css-selector": "^5.4 || ^6.0 || ^7.0",
+                "symfony/doctrine-bridge": "^5.4 || ^6.0 || ^7.0",
+                "symfony/dom-crawler": "^5.4 || ^6.0 || ^7.0",
+                "symfony/form": "^5.4 || ^6.0 || ^7.0",
+                "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0",
+                "symfony/phpunit-bridge": "^7.2",
+                "symfony/security-csrf": "^5.4 || ^6.0 || ^7.0",
+                "symfony/translation": "^5.4 || ^6.0 || ^7.0",
+                "symfony/twig-bridge": "^5.4 || ^6.0 || ^7.0",
+                "symfony/twig-bundle": "^5.4 || ^6.0 || ^7.0",
+                "symfony/validator": "^5.4 || ^6.0 || ^7.0",
+                "symfony/var-dumper": "^5.4 || ^6.0 || ^7.0",
+                "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "doctrine/doctrine-bundle": "For integration with Doctrine",
+                "doctrine/mongodb-odm-bundle": "For integration with Doctrine ODM",
+                "doctrine/orm": "For integration with Doctrine ORM",
+                "doctrine/phpcr-odm": "For integration with Doctrine PHPCR",
+                "knplabs/knp-gaufrette-bundle": "For integration with Gaufrette",
+                "league/flysystem-bundle": "For integration with Flysystem",
+                "liip/imagine-bundle": "To generate image thumbnails",
+                "oneup/flysystem-bundle": "For integration with Flysystem",
+                "symfony/asset": "To generate better links",
+                "symfony/form": "To handle uploads in forms",
+                "symfony/yaml": "To use YAML mapping"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Vich\\UploaderBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dustin Dobervich",
+                    "email": "ddobervich@gmail.com"
+                }
+            ],
+            "description": "Ease file uploads attached to entities",
+            "homepage": "https://github.com/dustin10/VichUploaderBundle",
+            "keywords": [
+                "file uploads",
+                "upload"
+            ],
+            "support": {
+                "issues": "https://github.com/dustin10/VichUploaderBundle/issues",
+                "source": "https://github.com/dustin10/VichUploaderBundle/tree/v2.7.0"
+            },
+            "time": "2025-06-12T06:59:34+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/backend/config/bundles.php
+++ b/backend/config/bundles.php
@@ -10,4 +10,5 @@ return [
     ApiPlatform\Symfony\Bundle\ApiPlatformBundle::class => ['all' => true],
     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
+    Vich\UploaderBundle\VichUploaderBundle::class => ['all' => true],
 ];

--- a/backend/config/packages/api_platform.yaml
+++ b/backend/config/packages/api_platform.yaml
@@ -1,7 +1,13 @@
 api_platform:
     title: Hello API Platform
     version: 1.0.0
+    formats:
+        jsonld: ['application/ld+json']
+        json: ['application/json']
+        html: ['text/html']
+        multipart: ['multipart/form-data']
     defaults:
         stateless: true
+        pagination_items_per_page: 10
         cache_headers:
             vary: ['Content-Type', 'Authorization', 'Origin']

--- a/backend/config/packages/vich_uploader.yaml
+++ b/backend/config/packages/vich_uploader.yaml
@@ -1,0 +1,9 @@
+vich_uploader:
+    db_driver: orm
+    storage: file_system
+
+    mappings:
+       question_images:
+           uri_prefix: /images/questions
+           upload_destination: '%kernel.project_dir%/public/images/questions'
+           namer: Vich\UploaderBundle\Naming\SmartUniqueNamer

--- a/backend/migrations/Version20250808144101.php
+++ b/backend/migrations/Version20250808144101.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250808144101 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE question ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
+        $this->addSql('COMMENT ON COLUMN question.updated_at IS \'(DC2Type:datetime_immutable)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE question DROP updated_at');
+    }
+}

--- a/backend/migrations/Version20250809163038.php
+++ b/backend/migrations/Version20250809163038.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250809163038 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+    }
+}

--- a/backend/migrations/Version20250811130535.php
+++ b/backend/migrations/Version20250811130535.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250811130535 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP SEQUENCE question_media_id_seq CASCADE');
+        $this->addSql('DROP TABLE question_media');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('CREATE SEQUENCE question_media_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
+        $this->addSql('CREATE TABLE question_media (id INT NOT NULL, file_path VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id))');
+    }
+}

--- a/backend/src/Controller/QuestionMediaUploadController.php
+++ b/backend/src/Controller/QuestionMediaUploadController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Question;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+
+#[AsController]
+class QuestionMediaUploadController
+{
+    public function __construct(private EntityManagerInterface $em) {}
+
+    public function __invoke(Request $request, int $id): JsonResponse
+    {
+        $question = $this->em->getRepository(Question::class)->find($id);
+
+        if (!$question) {
+            throw new NotFoundHttpException('Question not found.');
+        }
+
+        $file = $request->files->get('mediaFile');
+
+        if ($file) {
+            $question->setMediaFile($file);
+            $this->em->persist($question);
+            $this->em->flush();
+
+            return new JsonResponse(['status' => 'media updated']);
+        }
+
+        return new JsonResponse(['error' => 'No file uploaded'], 400);
+    }
+}

--- a/backend/src/Encoder/MultipartDecoder.php
+++ b/backend/src/Encoder/MultipartDecoder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Encoder;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+
+final class MultipartDecoder implements DecoderInterface
+{
+    public const FORMAT = 'multipart';
+
+    public function __construct(private readonly RequestStack $requestStack) {}
+
+    public function decode(string $data, string $format, array $context = []): ?array
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (!$request) {
+            return null;
+        }
+
+        return array_map(static function (string $element) {
+            try {
+                return json_decode($element, true, flags: \JSON_THROW_ON_ERROR);
+            } catch (\JsonException $e) {
+                return $element;
+            }
+        }, $request->request->all()) + $request->files->all();
+    }
+
+    public function supportsDecoding(string $format): bool
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/backend/src/Entity/Card.php
+++ b/backend/src/Entity/Card.php
@@ -7,6 +7,7 @@ use App\Repository\CardRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: CardRepository::class)]
 #[ApiResource]
@@ -18,6 +19,7 @@ class Card
     private ?int $id = null;
 
     #[ORM\Column]
+    #[Assert\Positive]
     private ?int $number = null;
 
     #[ORM\OneToMany(mappedBy: 'card', targetEntity: Question::class, cascade: ['persist', 'remove'])]

--- a/backend/src/Entity/Question.php
+++ b/backend/src/Entity/Question.php
@@ -2,12 +2,20 @@
 
 namespace App\Entity;
 
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use App\Repository\QuestionRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\Validator\Constraints as Assert;
+use Vich\UploaderBundle\Mapping\Annotation as Vich;
 
+#[Vich\Uploadable]
 #[ORM\Entity(repositoryClass: QuestionRepository::class)]
 #[ApiResource]
+#[ApiFilter(SearchFilter::class, properties: ['theme' => 'exact'])]
 class Question
 {
     #[ORM\Id]
@@ -16,20 +24,35 @@ class Question
     private ?int $id = null;
 
     #[ORM\Column(length: 255)]
+    #[Assert\NotBlank]
     private ?string $theme = null;
 
     #[ORM\Column(length: 255)]
+    #[Assert\NotBlank]
     private ?string $text = null;
 
     #[ORM\Column(length: 255)]
+    #[Assert\NotBlank]
     private ?string $answer = null;
 
     #[ORM\Column(length: 255, nullable: true)]
+    #[ApiProperty(writable: false)]
     private ?string $mediaUrl = null;
+
+    #[Vich\UploadableField(mapping: 'question_images', fileNameProperty: 'mediaUrl')]
+    #[Assert\Image]
+    private ?File $mediaFile = null;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $updatedAt = null;
 
     #[ORM\ManyToOne(inversedBy: 'questions')]
     #[ORM\JoinColumn(nullable: false)]
     private ?Card $card = null;
+
+    // #[ORM\ManyToOne(targetEntity: QuestionMedia::class)]
+    // #[ORM\JoinColumn(nullable: true)]
+    // public ?QuestionMedia $image = null;
 
     public function getId(): ?int
     {
@@ -72,6 +95,20 @@ class Question
         return $this;
     }
 
+    public function setMediaFile(?File $file = null): void
+    {
+        $this->mediaFile = $file;
+
+        if ($file !== null) {
+            $this->updatedAt = new \DateTimeImmutable();
+        }
+    }
+
+    public function getMediaFile(): ?File
+    {
+        return $this->mediaFile;
+    }
+
     public function getMediaUrl(): ?string
     {
         return $this->mediaUrl;
@@ -80,7 +117,6 @@ class Question
     public function setMediaUrl(?string $mediaUrl): static
     {
         $this->mediaUrl = $mediaUrl;
-
         return $this;
     }
 

--- a/backend/src/Entity/Question.php
+++ b/backend/src/Entity/Question.php
@@ -6,15 +6,55 @@ use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use App\Controller\QuestionMediaUploadController;
 use App\Repository\QuestionRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Validator\Constraints as Assert;
 use Vich\UploaderBundle\Mapping\Annotation as Vich;
+use ApiPlatform\OpenApi\Model\Operation;
+use ApiPlatform\OpenApi\Model\RequestBody;
 
 #[Vich\Uploadable]
 #[ORM\Entity(repositoryClass: QuestionRepository::class)]
-#[ApiResource]
+#[ApiResource(
+    operations: [
+        new Post(
+            uriTemplate: '/questions/{id}/media',
+            controller: QuestionMediaUploadController::class,
+            deserialize: false,
+            openapi: new Operation(
+                summary: 'Upload or replace the media file of a question',
+                requestBody: new RequestBody(
+                    description: 'Media file upload (JPG, PNG, GIF)',
+                    content: new \ArrayObject([
+                        'multipart/form-data' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    'mediaFile' => [
+                                        'type' => 'string',
+                                        'format' => 'binary'
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ])
+                )
+            )
+        )
+    ]
+)]
+#[GetCollection()]
+#[Get()]
+#[Post()]
+#[Patch()]
+#[Delete()]
 #[ApiFilter(SearchFilter::class, properties: ['theme' => 'exact'])]
 class Question
 {

--- a/backend/src/Serializer/QuestionNormalizer.php
+++ b/backend/src/Serializer/QuestionNormalizer.php
@@ -1,0 +1,48 @@
+<?php
+// api/src/Serializer/QuestionNormalizer.php
+
+namespace App\Serializer;
+
+use App\Entity\Question;
+use Vich\UploaderBundle\Storage\StorageInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class QuestionNormalizer implements NormalizerInterface
+{
+
+  private const ALREADY_CALLED = 'QUESTION_MEDIA_NORMALIZER_ALREADY_CALLED';
+
+  public function __construct(
+    #[Autowire(service: 'api_platform.jsonld.normalizer.item')]
+    private readonly NormalizerInterface $normalizer,
+    private readonly StorageInterface $storage
+  ) {
+  }
+
+  public function normalize($object, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+  {
+    $context[self::ALREADY_CALLED] = true;
+
+    $object->contentUrl = $this->storage->resolveUri($object, 'mediaFile');
+
+    return $this->normalizer->normalize($object, $format, $context);
+  }
+
+  public function supportsNormalization($data, ?string $format = null, array $context = []): bool
+  {
+
+    if (isset($context[self::ALREADY_CALLED])) {
+      return false;
+    }
+
+    return $data instanceof Question;
+  }
+
+  public function getSupportedTypes(?string $format): array
+  {
+    return [
+      Question::class => true,
+    ];
+  }
+}

--- a/backend/src/Serializer/QuestionNormalizer.php
+++ b/backend/src/Serializer/QuestionNormalizer.php
@@ -1,5 +1,4 @@
 <?php
-// api/src/Serializer/QuestionNormalizer.php
 
 namespace App\Serializer;
 

--- a/backend/src/Serializer/UploadedFileDenormalizer.php
+++ b/backend/src/Serializer/UploadedFileDenormalizer.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Serializer;
+
+use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+final class UploadedFileDenormalizer implements DenormalizerInterface
+{
+    public function denormalize($data, string $type, string $format = null, array $context = []): File
+    {
+        return $data;
+    }
+
+    public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
+    {
+        return $data instanceof File;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            File::class => true,
+        ];
+    }
+}

--- a/backend/symfony.lock
+++ b/backend/symfony.lock
@@ -204,5 +204,17 @@
             "config/packages/web_profiler.yaml",
             "config/routes/web_profiler.yaml"
         ]
+    },
+    "vich/uploader-bundle": {
+        "version": "2.7",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "1.13",
+            "ref": "1b3064c2f6b255c2bc2f56461aaeb76b11e07e36"
+        },
+        "files": [
+            "config/packages/vich_uploader.yaml"
+        ]
     }
 }

--- a/backend/tests/Integration/Controller/QuestionMediaUploadControllerTest.php
+++ b/backend/tests/Integration/Controller/QuestionMediaUploadControllerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Tests\Integration\Controller;
+
+use App\Entity\Card;
+use App\Entity\Question;
+use App\Service\Factory\QuestionFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+class QuestionMediaUploadControllerTest extends WebTestCase
+{
+    private EntityManagerInterface $em;
+    private $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+    }
+
+    public function testUploadMediaToQuestion(): void
+    {
+        $card = new Card();
+        $card->setNumber(1);
+
+        $factory = new QuestionFactory();
+        $question = $factory->createAndAddToCard($card, 'QSER', 'Quel est l\'intérêt de la position nuit ?', 'Ne pas être ébloui par les feux du véhicule suiveur.');
+
+        $this->em->persist($card);     
+        $this->em->persist($question); 
+        $this->em->flush();
+
+        $questionId = $question->getId();
+
+        $filePath = __DIR__ . '/fixtures/test-image.jpg';
+        copy(__DIR__ . '/../../fixtures/test.jpg', $filePath);
+        $uploadedFile = new UploadedFile(
+            $filePath,
+            'test-image.jpg',
+            'image/jpeg',
+            null,
+            true
+        );
+
+        $this->client->request(
+            'POST',
+            "/api/questions/{$questionId}/media",
+            [],
+            ['mediaFile' => $uploadedFile]
+        );
+
+        // Assert the response status and content
+        $this->assertResponseIsSuccessful();
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertSame('media updated', $response['status']);
+
+        // Check if the media URL is set in the question entity
+        $this->em->clear();
+        $updatedQuestion = $this->em->getRepository(Question::class)->find($questionId);
+        $this->assertNotNull($updatedQuestion->getMediaUrl(), 'Media URL should be set in DB');
+    }
+}


### PR DESCRIPTION
 This PR adds full support for uploading media files to questions, including backend API changes, database migrations, file handling configuration, and integration tests.

Changes included:

- API support
  - Added controller endpoint to handle media upload for questions (/questions/{id}/media)
  - Added support for multipart/form-data requests
  - Added custom serialization for uploaded media data

- File upload handling
  - Installed and configured VichUploaderBundle
  - Added file validation rules

- Database
  - Added migrations to support storing media URL in question table

- Tests
  - Added integration test to validate media upload endpoint (QuestionMediaUploadControllerTest)